### PR TITLE
Add emotion analysis to chat endpoint

### DIFF
--- a/backend/emotion_classifier.py
+++ b/backend/emotion_classifier.py
@@ -1,0 +1,28 @@
+# Simple emotion classifier placeholder
+# Returns sentiment (positive, negative, mixed, or neutral) and list of detected keywords
+
+def classify_emotion(message: str):
+    """Classify the sentiment of a message and extract keywords.
+
+    This is a placeholder implementation based on keyword matching.
+    """
+    positive_keywords = ["행복", "좋아", "기쁨", "즐겁", "사랑", "감사"]
+    negative_keywords = ["슬퍼", "우울", "싫어", "화나", "짜증", "불안"]
+
+    found_positive = [kw for kw in positive_keywords if kw in message]
+    found_negative = [kw for kw in negative_keywords if kw in message]
+
+    if found_positive and not found_negative:
+        sentiment = "positive"
+        keywords = found_positive
+    elif found_negative and not found_positive:
+        sentiment = "negative"
+        keywords = found_negative
+    elif found_positive and found_negative:
+        sentiment = "mixed"
+        keywords = found_positive + found_negative
+    else:
+        sentiment = "neutral"
+        keywords = []
+
+    return sentiment, keywords

--- a/backend/redis/test_redis.py
+++ b/backend/redis/test_redis.py
@@ -1,5 +1,7 @@
 from datetime import datetime
-from redis_emotion import save_emotion_analysis, get_emotion_history
+import pytest
+pytest.skip("example script - skip during tests", allow_module_level=True)
+from .redis_emotion import save_emotion_analysis, get_emotion_history
 
 # 테스트 데이터
 user_id = "testuser01"
@@ -9,11 +11,12 @@ keywords = ["행복", "즐거움", "기쁨"]
 timestamp = datetime.now().isoformat()
 
 # 저장
-save_emotion_analysis(user_id, timestamp, message, sentiment, keywords)
-print("✅ 감정 분석 결과 저장 완료")
+if __name__ == "__main__":
+    save_emotion_analysis(user_id, timestamp, message, sentiment, keywords)
+    print("✅ 감정 분석 결과 저장 완료")
 
-# 조회
-history = get_emotion_history(user_id)
-print("🧾 최근 감정 히스토리:")
-for record in history:
-    print(record)
+    # 조회
+    history = get_emotion_history(user_id)
+    print("🧾 최근 감정 히스토리:")
+    for record in history:
+        print(record)


### PR DESCRIPTION
## Summary
- add simple emotion classifier placeholder
- integrate classifier into `/chat` endpoint
- store emotion analysis in Redis
- skip example script during tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685cdd9fd83483319705254065c5f5c3