### PR TITLE
Add configurable API base helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,3 +34,7 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 The easiest way to deploy your Next.js app is to use the [Vercel Platform](https://vercel.com/new?utm_medium=default-template&filter=next.js&utm_source=create-next-app&utm_campaign=create-next-app-readme) from the creators of Next.js.
 
 Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/building-your-application/deploying) for more details.
+
+## Environment Variables
+
+`NEXT_PUBLIC_API_BASE` sets the base URL used by frontend API calls. If not provided, `/` is used.

--- a/components/chat-interface.tsx
+++ b/components/chat-interface.tsx
@@ -3,6 +3,7 @@
 import type React from "react"
 
 import { useState, useRef, useEffect } from "react"
+import { getApiBase } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Send, Clock } from "lucide-react"
@@ -82,7 +83,7 @@ export default function ChatInterface({ user }: ChatInterfaceProps) {
     }
 
     try {
-      const response = await fetch("/chat", {
+      const response = await fetch(`${getApiBase()}chat`, {
         method: "POST",
         headers: {
           "Content-Type": "application/json",

--- a/components/signup.tsx
+++ b/components/signup.tsx
@@ -1,6 +1,7 @@
 "use client"
 
 import { useState } from "react"
+import { getApiBase } from "@/lib/api"
 import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Textarea } from "@/components/ui/textarea"
@@ -75,7 +76,7 @@ const handleSubmit = async () => {
   setStep("submitting");
 
   try {
-    const response = await fetch("/signup", {
+    const response = await fetch(`${getApiBase()}signup`, {
       method: "POST",
       headers: {
         "Content-Type": "application/json",

--- a/lib/api.ts
+++ b/lib/api.ts
@@ -1,0 +1,5 @@
+export function getApiBase(): string {
+  const base = process.env.NEXT_PUBLIC_API_BASE;
+  if (!base) return '/';
+  return base.endsWith('/') ? base : `${base}/`;
+}


### PR DESCRIPTION
## Summary
- add `getApiBase` helper to centralize API URL prefix
- use the helper for signup and chat requests
- document `NEXT_PUBLIC_API_BASE` in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ce63287ac8331a7de177517898b42