### PR TITLE
Improve emotion classification with training

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,11 @@ Check out our [Next.js deployment documentation](https://nextjs.org/docs/app/bui
 ## Environment Variables
 
 `NEXT_PUBLIC_API_BASE` sets the base URL used by frontend API calls. If not provided, `/` is used.
+
+## Emotion Training
+
+Run `backend/emotion_trainer.py` with your labeled chat CSV files to build an
+`emotion_rules.json` file used by the API. Each CSV should contain `message` and
+`emotion` columns (or `text`/`label`). The generated rules allow
+`classify_emotion` to infer emotions such as "기쁨" or "슬픔" from incoming
+messages.

--- a/backend/emotion_trainer.py
+++ b/backend/emotion_trainer.py
@@ -1,0 +1,48 @@
+import csv
+import json
+import os
+import re
+import sys
+from collections import Counter, defaultdict
+
+
+def tokenize(text: str):
+    return re.findall(r"[가-힣a-zA-Z]+", text)
+
+
+def train(files, top_n=10):
+    emotion_counts: dict[str, Counter] = defaultdict(Counter)
+    for path in files:
+        with open(path, encoding="utf-8") as f:
+            reader = csv.DictReader(f)
+            if not reader.fieldnames:
+                continue
+            # Determine column names
+            if "message" in reader.fieldnames and "emotion" in reader.fieldnames:
+                msg_field, emo_field = "message", "emotion"
+            elif "text" in reader.fieldnames and "label" in reader.fieldnames:
+                msg_field, emo_field = "text", "label"
+            else:
+                msg_field, emo_field = reader.fieldnames[0], reader.fieldnames[1]
+
+            for row in reader:
+                message = row.get(msg_field, "")
+                emotion = row.get(emo_field, "neutral")
+                for word in tokenize(message):
+                    emotion_counts[emotion][word] += 1
+
+    rules = {
+        emotion: [w for w, _ in counter.most_common(top_n)]
+        for emotion, counter in emotion_counts.items()
+    }
+    out_path = os.path.join(os.path.dirname(__file__), "emotion_rules.json")
+    with open(out_path, "w", encoding="utf-8") as f:
+        json.dump(rules, f, ensure_ascii=False, indent=2)
+    print(f"Saved emotion rules to {out_path}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: python emotion_trainer.py file1.csv [file2.csv ...]")
+        sys.exit(1)
+    train(sys.argv[1:])

--- a/backend/main.py
+++ b/backend/main.py
@@ -99,19 +99,19 @@ def chat(chat: ChatInput):
     context = get_recent_messages(chat.userId)
 
     try:
-        sentiment, keywords = classify_emotion(chat.message)
+        emotion, keywords = classify_emotion(chat.message)
         save_emotion_analysis(
             chat.userId,
             datetime.now().isoformat(),
             chat.message,
-            sentiment,
+            emotion,
             keywords,
         )
     except Exception as e:
         print(f"Emotion classification failed: {e}")
-        sentiment = "unknown"
+        emotion = "unknown"
 
-    return {"context": context, "reply": "AI 응답 예시", "sentiment": sentiment}
+    return {"context": context, "reply": "AI 응답 예시", "emotion": emotion}
 
 @app.get("/chat/context/{user_id}")
 def get_chat_context(user_id: str):

--- a/backend/redis/redis_emotion.py
+++ b/backend/redis/redis_emotion.py
@@ -4,12 +4,12 @@ import json
 
 redis = Redis(host="localhost", port=6379, decode_responses=True)
 
-def save_emotion_analysis(user_id: str, timestamp: str, message: str, sentiment: str, keywords: list):
+def save_emotion_analysis(user_id: str, timestamp: str, message: str, emotion: str, keywords: list):
     key = f"chat:emotion:{user_id}"
     data = {
         "timestamp": timestamp,
         "message": message,
-        "sentiment": sentiment,
+        "emotion": emotion,
         "keywords": keywords
     }
     redis.rpush(key, json.dumps(data))

--- a/backend/redis/test_redis.py
+++ b/backend/redis/test_redis.py
@@ -6,13 +6,13 @@ from .redis_emotion import save_emotion_analysis, get_emotion_history
 # 테스트 데이터
 user_id = "testuser01"
 message = "요즘 너무 즐겁고 행복해!"
-sentiment = "긍정"
+emotion = "긍정"
 keywords = ["행복", "즐거움", "기쁨"]
 timestamp = datetime.now().isoformat()
 
 # 저장
 if __name__ == "__main__":
-    save_emotion_analysis(user_id, timestamp, message, sentiment, keywords)
+    save_emotion_analysis(user_id, timestamp, message, emotion, keywords)
     print("✅ 감정 분석 결과 저장 완료")
 
     # 조회


### PR DESCRIPTION
## Summary
- add a training script to generate keyword rules from CSV chat logs
- load generated rules in `emotion_classifier`
- expose detected emotion in `/chat` responses
- document emotion training in README
- rename `sentiment` fields to `emotion`

## Testing
- `python -m py_compile backend/emotion_classifier.py backend/emotion_trainer.py backend/main.py backend/redis/redis_emotion.py backend/redis/test_redis.py`


------
https://chatgpt.com/codex/tasks/task_e_685cb2fc71588331bae210f5e0d24f26