### PR TITLE
Handle GPT failures gracefully

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,11 +53,6 @@ messages.
 OpenAI's GPT model to detect an emotion and related keywords from a chat
 message. Set the `OPENAI_API_KEY` environment variable and the API will attempt
 this method first, falling back to the local rules when GPT is unavailable.
-
-<<<<<<< ntoxk7-codex/유저-감정-분류-및-키워드-저장-구현
-=======
-
->>>>>>> main
 ### Redis Chat Storage
 
 Chat records in Redis include the user's emotion so that UIs can display an
@@ -73,7 +68,3 @@ following structure:
   "keywords": ["우울", "힘들어"]
 }
 ```
-<<<<<<< ntoxk7-codex/유저-감정-분류-및-키워드-저장-구현
-
-=======
->>>>>>> main

--- a/backend/main.py
+++ b/backend/main.py
@@ -116,11 +116,15 @@ def chat_with_ai(chat: ChatInput):
         ]
 
         # 4️⃣ GPT 응답 생성 (OpenAI v1 방식)
-        response = client.chat.completions.create(
-            model="gpt-3.5-turbo",
-            messages=prompt
-        )
-        reply_text = response.choices[0].message.content.strip()
+        try:
+            response = client.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=prompt
+            )
+            reply_text = response.choices[0].message.content.strip()
+        except Exception as gpt_error:
+            print(f"⚠️ GPT 호출 실패: {gpt_error}")
+            reply_text = "죄송합니다. 현재 답변을 생성할 수 없습니다."
 
         # 5️⃣ Redis 저장
         timestamp = datetime.now().isoformat()


### PR DESCRIPTION
## Summary
- avoid raising 500 when GPT call fails and send a friendly fallback message instead
- clean up README merge markers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685d56a8ab3883318e72b5639f1aa431